### PR TITLE
Fix duplicate boxShadow key

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,7 +57,7 @@ module.exports = {
         card: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
         'card-hover':
           '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-        card: '0 4px 24px 0 rgba(60, 40, 20, 0.15)',
+        'card-lg': '0 4px 24px 0 rgba(60, 40, 20, 0.15)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- rename duplicate `card` key in `boxShadow` object to `card-lg`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*