### PR TITLE
Unify earth tone theme across layout

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,6 @@
-﻿export default function Footer() {
+export default function Footer() {
   return (
-    <footer className="bg-gray-800 text-white p-4 mt-8">
+    <footer className="bg-earth-card text-earth py-4 mt-8 border-t border-earth">
       <div className="max-w-7xl mx-auto text-center text-sm">
         &copy; {new Date().getFullYear()} Uncompiled Insanity. All rights
         reserved.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,10 @@
-﻿import Link from 'next/link';
+import Link from 'next/link';
 
 export default function Header() {
   return (
-    <header className="bg-blue-600 text-white p-4">
-      <div className="max-w-7xl mx-auto">
-        <h1 className="text-2xl font-bold">
+    <header className="bg-earth-card text-earth py-4 shadow-md">
+      <div className="max-w-7xl mx-auto px-4">
+        <h1 className="text-2xl font-extrabold text-earth-primary">
           <Link href="/">Uncompiled Insanity</Link>
         </h1>
       </div>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,9 +1,15 @@
-﻿import React from 'react';
+import React from 'react';
+import Header from './Header';
+import NavBar from './NavBar';
+import Footer from './Footer';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen w-full bg-[#f8fafc] dark:bg-[#111827]">
-      {children}
+    <div className="min-h-screen flex flex-col bg-earth-background text-earth">
+      <Header />
+      <NavBar />
+      <main className="flex-1">{children}</main>
+      <Footer />
     </div>
   );
 }

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,36 +1,36 @@
-﻿import Link from 'next/link';
+import Link from 'next/link';
 
 export default function NavBar() {
   return (
-    <nav className="bg-white border-b border-gray-200">
+    <nav className="bg-earth-background border-b border-earth">
       <div className="max-w-7xl mx-auto px-4 py-2 flex flex-col sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <Link href="/" className="text-2xl font-bold">
-            Net Worth
+          <Link href="/" className="text-lg font-semibold text-earth-primary">
+            Home
           </Link>
         </div>
         <div className="flex flex-col sm:flex-row sm:space-x-6 space-y-1 sm:space-y-0 mt-2 sm:mt-0">
-          <Link href="/" className="text-gray-700 hover:text-blue-500">
+          <Link href="/" className="text-earth hover:text-earth-primary">
             Net Worth
           </Link>
           <Link
             href="/data-entry"
-            className="text-gray-700 hover:text-blue-500"
+            className="text-earth hover:text-earth-primary"
           >
             Data Entry
           </Link>
           <Link
             href="/debt-tracker"
-            className="text-gray-700 hover:text-blue-500"
+            className="text-earth hover:text-earth-primary"
           >
             Debt Tracker
           </Link>
-          <Link href="/budget" className="text-gray-700 hover:text-blue-500">
+          <Link href="/budget" className="text-earth hover:text-earth-primary">
             Budget
           </Link>
           <Link
             href="/budget-playground"
-            className="text-gray-700 hover:text-blue-500"
+            className="text-earth hover:text-earth-primary"
           >
             Budget Playground
           </Link>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  js.configs.recommended,
+  tseslint.configs.recommended,
+  {
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 2021,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+    },
+    rules: {},
+  },
+  prettier
+);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
-﻿import '@/styles/globals.css';
+import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import { useEffect } from 'react';
+import Layout from '@/components/Layout';
 
 // Import Poppins font from Google Fonts
 import '@fontsource/poppins/400.css';
@@ -20,5 +21,9 @@ export default function App({ Component, pageProps }: AppProps) {
     }
   }, []);
 
-  return <Component {...pageProps} />;
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
 }

--- a/pages/budget.tsx
+++ b/pages/budget.tsx
@@ -1,10 +1,10 @@
-﻿export default function Budget() {
+export default function Budget() {
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-3xl font-semibold mb-2">Budget</h1>
-      <p className="text-gray-600">
-        A clean visual view of your current budget breakdown.
-      </p>
+    <div className="container mx-auto p-4 text-earth">
+      <h1 className="text-3xl font-extrabold mb-2 text-earth-primary">
+        Budget
+      </h1>
+      <p>A clean visual view of your current budget breakdown.</p>
     </div>
   );
 }

--- a/pages/debt-tracker.tsx
+++ b/pages/debt-tracker.tsx
@@ -1,10 +1,10 @@
-﻿export default function DebtTracker() {
+export default function DebtTracker() {
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-3xl font-semibold mb-2">Debt Tracker</h1>
-      <p className="text-gray-600">
-        Add or subtract amounts to track your debt balances over time.
-      </p>
+    <div className="container mx-auto p-4 text-earth">
+      <h1 className="text-3xl font-extrabold mb-2 text-earth-primary">
+        Debt Tracker
+      </h1>
+      <p>Add or subtract amounts to track your debt balances over time.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- introduce global layout with earth theme header/footer/navigation
- restyle simple pages to use new theme classes
- wrap app with the new layout
- add flat ESLint config (ESM style)

## Testing
- `npm run format`
- `npm run lint` *(fails: A config object is using the "parser" key, which is not supported in flat config system)*