### PR TITLE
Add simple password gate and API auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ The **Personal Financial Tracker** is an intuitive web application designed to c
 
 - **Vercel**: Efficient, scalable deployment and hosting.
 
+### Access Control
+
+The dashboard is protected by a simple password. Set the `SITE_PASSWORD`
+environment variable to configure the password (defaults to `TEST`). Users are
+redirected to `/login` and must enter the password before any API routes or
+database queries can be accessed.
+
 ---
 
 ## 💡 Current State

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith('/api/login') || pathname === '/login') {
+    return NextResponse.next();
+  }
+
+  const auth = req.cookies.get('auth');
+
+  if (auth?.value === 'true') {
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith('/api')) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const loginUrl = req.nextUrl.clone();
+  loginUrl.pathname = '/login';
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};

--- a/pages/api/get-checkins.ts
+++ b/pages/api/get-checkins.ts
@@ -1,7 +1,14 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '../../lib/supabaseClient';
 
+function isAuthed(req: NextApiRequest) {
+  return req.cookies?.auth === 'true';
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!isAuthed(req)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
   const { data, error } = await supabase
     .from('monthly_checkins')
     .select('*')

--- a/pages/api/live-prices.ts
+++ b/pages/api/live-prices.ts
@@ -1,6 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '@/utils/supabaseClient';
 
+function isAuthed(req: NextApiRequest) {
+  return req.cookies?.auth === 'true';
+}
+
 // Types for price data
 interface PriceData {
   ticker: string;
@@ -155,6 +159,9 @@ async function fetchStockAndEtfPrices(tickers: string[]): Promise<PriceData[]> {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!isAuthed(req)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { password } = req.body;
+  const sitePassword = process.env.SITE_PASSWORD || 'TEST';
+
+  if (password === sitePassword) {
+    res.setHeader('Set-Cookie', 'auth=true; Path=/; HttpOnly; SameSite=Lax');
+    return res.status(200).json({ success: true });
+  }
+
+  return res.status(401).json({ error: 'Invalid password' });
+}

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Set-Cookie', 'auth=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax');
+  return res.status(200).json({ success: true });
+}

--- a/pages/api/save-checkin.ts
+++ b/pages/api/save-checkin.ts
@@ -1,9 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '../../lib/supabaseClient';
 
+function isAuthed(req: NextApiRequest) {
+  return req.cookies?.auth === 'true';
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     console.log('BODY:', req.body);
+
+    if (!isAuthed(req)) return res.status(401).json({ error: 'Unauthorized' });
 
     if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    });
+    if (res.ok) {
+      router.push('/');
+    } else {
+      const data = await res.json();
+      setError(data.error || 'Invalid password');
+    }
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-earth-background text-earth">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-earth-card p-6 rounded-xl shadow-card flex flex-col gap-4 border border-earth"
+      >
+        <h1 className="text-2xl font-bold text-center text-earth-primary">Login</h1>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-64 px-3 py-2 rounded border border-earth bg-earth-background focus:outline-none focus:ring-2 focus:ring-earth-accent"
+          placeholder="Password"
+        />
+        <button
+          type="submit"
+          className="py-2 px-4 rounded bg-earth-accent text-earth font-bold hover:bg-earth-accent2 transition"
+        >
+          Enter
+        </button>
+        {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- implement middleware to redirect to `/login` when not authenticated
- add `/login` page and login/logout API routes
- check authentication cookie in data API routes
- document new `SITE_PASSWORD` environment variable in README

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*